### PR TITLE
added support for property files without a proper extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,16 @@ Further transform the resulting output. It has the same usage as for [JSON.strin
 _The option is used only when namespace option is an empty string._
 
 
+#### options.appendExt
+
+Type: `Boolean`
+
+Default: `false`
+
+Append the extension (`.js` || `.json`) instead of replacing it.
+
+_Useful if the property files doens't have an extension._
+
 ## License
 
 MIT © [Cristian Trifan](http://crissdev.com)

--- a/index.js
+++ b/index.js
@@ -52,10 +52,16 @@ function props2json(buffer, options) {
     return new Buffer(output);
 }
 
+function outputFilename(filepath, options) {
+    return (options.appendExt) ?
+        filepath + (options.namespace ? '.js' : '.json') :
+            gutil.replaceExtension(filepath, options.namespace ? '.js' : '.json');
+}
+
 
 module.exports = function(options) {
     var self = this;
-    options = extend({ namespace: 'config', space: null, replacer: null }, options);
+    options = extend({ namespace: 'config', space: null, replacer: null, replaceExt: false }, options);
 
     return through.obj(function(file, enc, callback) {
         if (options.namespace) {
@@ -76,7 +82,7 @@ module.exports = function(options) {
                     try {
                         cb(null, props2json(buf, options));
                         file.contents = props2json(file.contents, options);
-                        file.path = gutil.replaceExtension(file.path, options.namespace ? '.js' : '.json');
+                        file.path = outputFilename(file.path, options);
                     }
                     catch (error) {
                         self.emit('error', new PluginError(PLUGIN_NAME, error.message));
@@ -88,7 +94,7 @@ module.exports = function(options) {
         else if (file.isBuffer()) {
             try {
                 file.contents = props2json(file.contents, options);
-                file.path = gutil.replaceExtension(file.path, options.namespace ? '.js' : '.json');
+                file.path = outputFilename(file.path, options);
             }
             catch (error) {
                 this.emit('error', new PluginError(PLUGIN_NAME, error.message));

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ function outputFilename(filepath, options) {
 
 module.exports = function(options) {
     var self = this;
-    options = extend({ namespace: 'config', space: null, replacer: null, replaceExt: false }, options);
+    options = extend({ namespace: 'config', space: null, replacer: null, appendExt: false }, options);
 
     return through.obj(function(file, enc, callback) {
         if (options.namespace) {

--- a/test/main.js
+++ b/test/main.js
@@ -16,6 +16,7 @@ describe('gulp-props', function() {
     // Test files
 
     var validFile,
+        noExtFile,
         emptyFile,
         specialFile,
         nullFile;
@@ -29,6 +30,11 @@ describe('gulp-props', function() {
                 cwd: 'test',
                 contents: fs.readFileSync('test/valid.properties')
             });
+            noExtFile = new File({
+                path: 'test/noExt.1',
+                cwd: 'test',
+                contents: new Buffer('test/noExt.1')
+            });
             emptyFile = new File({
                 path: 'test/empty.properties',
                 cwd: 'test',
@@ -39,6 +45,7 @@ describe('gulp-props', function() {
                 cwd: 'test',
                 contents: fs.readFileSync('test/special.properties')
             });
+
             nullFile = new File({
                 cwd: 'test',
                 contents: null
@@ -132,6 +139,18 @@ describe('gulp-props', function() {
             });
 
             stream.write(validFile);
+            stream.end();
+        });
+
+        it('should append the extension instead of replacing it if appendExt flag is active', function(done) {
+            var stream = props({ appendExt: true });
+
+            stream.once('data', function(file) {
+                path.basename(file.path).should.equal('noExt.1.js');
+                done();
+            });
+
+            stream.write(noExtFile);
             stream.end();
         });
 

--- a/test/noExt.1
+++ b/test/noExt.1
@@ -1,0 +1,3 @@
+! Java .properties files are a good choice for internationalization and localization
+name = Gulp
+message = Hi!


### PR DESCRIPTION
I'm trying to use your gulp plugin with some property files without a proper extension (specifically the messages files of Play Framework). In my case the structure of the folder is:
```
conf/messages
conf/messages.it
conf/messages.de
...
```
With the replacement of the extension by default, the output of each of them overwrites the file ```messages.json```, so I introduced an ```appendExt``` option in my fork to avoid this happening.

Let me know if you'd wish me to make any change to it.

ps: I didn't bump the version yet, I thought you might wanted to do it yourself if and when you'd wish to create a new release of the module